### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Nmsyah99/11907a47-40e3-4b56-81df-5115048f247c/048d75f6-8abc-4f70-b7bb-b178bf0772fb/_apis/work/boardbadge/48a82e79-6274-44fe-bd8c-94b078b2b8ca)](https://dev.azure.com/Nmsyah99/11907a47-40e3-4b56-81df-5115048f247c/_boards/board/t/048d75f6-8abc-4f70-b7bb-b178bf0772fb/Microsoft.RequirementCategory)
 # GitHub Explore
 
 This repository houses all of the community-curated content for GitHub Topics and Collections.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Nmsyah99/11907a47-40e3-4b56-81df-5115048f247c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.